### PR TITLE
Resolve closure before returning

### DIFF
--- a/src/DependencyResolver/ConstructorDependencyResolver.php
+++ b/src/DependencyResolver/ConstructorDependencyResolver.php
@@ -56,7 +56,12 @@ class ConstructorDependencyResolver implements ResolverInterface
         if (null !== $dependencyName) {
             // Return named parameter
             if ($container->has($dependencyName)) {
-                return $container->get($dependencyName);
+                $entry = $container->get($dependencyName);
+                if ($entry instanceOf \Closure) {
+                    return $entry();
+                } else {
+                    return $entry;
+                }
             }
 
             // Returned aliased service


### PR DESCRIPTION
In GemsTracker, I found that ServerRequestInterface was aliased to Container\ServerRequestFactoryFactory, which returns a closure when invoked. This caused the DI to fail with:

  Argument #5 ($request) must be of type
  Psr\Http\Message\ServerRequestInterface, Closure given, called
  in /app/vendor/magnafacta/zalt-loader/src/ProjectOverloader.php
  on line 320

This fixes that, by returning the result of the closure instead of the closure itself.